### PR TITLE
Add CodePilot web app skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# Jarvis
+# CodePilot
+
+CodePilot is a web application that generates full HTML/CSS/JS code from a natural language prompt using OpenAI's API. The interface includes an editor and live preview so you can tweak the generated code in real time.
+
+## Project Structure
+
+```
+/codepilot-app
+  /client      - React frontend built with Vite and Tailwind CSS
+  /server      - Express backend
+```
+
+## Setup
+
+### Prerequisites
+- Node.js 18+
+- npm
+
+### Backend
+
+1. Copy `.env.example` to `.env` and add your OpenAI API key.
+2. Install dependencies and start the server:
+
+```bash
+cd server
+npm install
+node index.js
+```
+
+### Frontend
+
+In a new terminal:
+
+```bash
+cd client
+npm install
+npm run dev
+```
+
+The frontend runs on `http://localhost:5173` and proxies API requests to the backend on port `5000`.
+
+## Usage
+
+1. Enter a prompt such as `"Create a landing page for a coffee shop with a hero banner, menu section, and contact form"`.
+2. Click **Generate** to send the prompt to the backend.
+3. The generated HTML appears in the editor and is rendered in the preview pane.
+4. Edit the code if desired and copy it from the editor.
+
+## Exporting
+
+To export the generated code manually, copy it from the editor and save it as an `.html` file. (A zip export button can be implemented as an improvement.)
+
+## License
+MIT

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CodePilot</title>
+  </head>
+  <body class="bg-gray-900 text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "codepilot-client",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@monaco-editor/react": "^4.4.6"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.0"
+  }
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import PromptForm from './components/PromptForm';
+import CodeEditor from './components/CodeEditor';
+import LivePreview from './components/LivePreview';
+
+function App() {
+  const [code, setCode] = useState(`<!DOCTYPE html>
+<html>
+<head>
+  <style>body {font-family: Arial;}</style>
+</head>
+<body>
+  <h1>Hello CodePilot</h1>
+</body>
+</html>`);
+
+  return (
+    <div className="flex h-full">
+      <div className="w-1/2 p-4 space-y-4 overflow-y-auto">
+        <PromptForm onCode={setCode} />
+        <CodeEditor code={code} setCode={setCode} />
+      </div>
+      <div className="w-1/2 p-4 bg-gray-800 overflow-y-auto">
+        <LivePreview code={code} />
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/client/src/components/CodeEditor.tsx
+++ b/client/src/components/CodeEditor.tsx
@@ -1,0 +1,20 @@
+import Editor from '@monaco-editor/react';
+
+interface Props {
+  code: string;
+  setCode: (code: string) => void;
+}
+
+export default function CodeEditor({ code, setCode }: Props) {
+  return (
+    <div className="h-96 border border-gray-700">
+      <Editor
+        height="100%"
+        defaultLanguage="html"
+        value={code}
+        onChange={(value) => setCode(value || '')}
+        theme="vs-dark"
+      />
+    </div>
+  );
+}

--- a/client/src/components/LivePreview.tsx
+++ b/client/src/components/LivePreview.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  code: string;
+}
+
+export default function LivePreview({ code }: Props) {
+  return (
+    <iframe
+      title="preview"
+      className="w-full h-full bg-white"
+      srcDoc={code}
+    />
+  );
+}

--- a/client/src/components/PromptForm.tsx
+++ b/client/src/components/PromptForm.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+interface Props {
+  onCode: (code: string) => void;
+}
+
+export default function PromptForm({ onCode }: Props) {
+  const [prompt, setPrompt] = useState('Create a landing page for a coffee shop with a hero banner, menu section, and contact form');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const res = await axios.post('/api/generate', { prompt });
+      onCode(res.data.code);
+    } catch (err) {
+      setError('Failed to generate code.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        className="w-full p-2 rounded bg-gray-800 text-gray-100"
+        rows={3}
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+      ></textarea>
+      <button
+        type="submit"
+        className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-700"
+        disabled={loading}
+      >
+        {loading ? 'Generating...' : 'Generate'}
+      </button>
+      {error && <p className="text-red-500">{error}</p>}
+    </form>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path": "./tsconfig.node.json"}]
+}

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
+  }
+});

--- a/routes/generateCode.js
+++ b/routes/generateCode.js
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import { Configuration, OpenAIApi } from 'openai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const router = Router();
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const openai = new OpenAIApi(configuration);
+
+router.post('/', async (req, res) => {
+  const { prompt } = req.body;
+  if (!prompt) {
+    return res.status(400).json({ error: 'Prompt is required' });
+  }
+  try {
+    const completion = await openai.createCompletion({
+      model: 'gpt-4o',
+      prompt: `Generate a complete HTML, CSS and JS code snippet. ${prompt}`,
+      temperature: 0.7,
+      max_tokens: 1000,
+    });
+    const code = completion.data.choices[0].text || '';
+    res.json({ code });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to generate code' });
+  }
+});
+
+export default router;

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import generateRoute from '../routes/generateCode.js';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/generate', generateRoute);
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "codepilot-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.4",
+    "express": "^4.18.2",
+    "openai": "^4.21.0"
+  }
+}


### PR DESCRIPTION
## Summary
- implement React/Vite/Tailwind client with Monaco editor
- add Express server with OpenAI integration route
- provide environment variable template and project README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687babd77d4c83339d87e7e5d76a6ebf